### PR TITLE
Allow passing number of master and worker nodes as arguments

### DIFF
--- a/cluster/kind-replica1.sh
+++ b/cluster/kind-replica1.sh
@@ -4,6 +4,8 @@ OPENSHIFTKNI_CI_KIND_IMAGE=${OPENSHIFTKNI_CI_KIND_IMAGE:-'kindest/node:v1.19.1@s
 
 ACTION=${1}
 CLUSTER_NAME=${2:-kni-test}
+MASTER_NUM=${3:-1}
+WORKER_NUM=${4:-1}
 
 which kind &> /dev/null || exit 1
 
@@ -27,9 +29,21 @@ kubeadmConfigPatches:
   topologyManagerPolicy: "single-numa-node"
   reservedSystemCPUs: "1"
 nodes:
-- role: control-plane
-- role: worker
 EOF
+counter=1
+while [ $counter -le $MASTER_NUM ]
+do
+ echo "- role: control-plane" >> ${CONTEXT}/kindconfig.yaml
+((counter++))
+done
+
+counter=1
+while [ $counter -le $WORKER_NUM	 ]
+do
+ echo "- role: worker" >> ${CONTEXT}/kindconfig.yaml
+ ((counter++))
+done
+
 	kind create cluster \
 		--kubeconfig ${CONTEXT}/kubeconfig \
 		--config ${CONTEXT}/kindconfig.yaml \


### PR DESCRIPTION
 - This PR allows to parameterise the number of control plane nodes and worker nodes
 - Generates kind config based on the specified number and hence enables creation of
   kind clusters with variable node sizes
 - By default, it continues to create one control-plane node and one worker-node

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>