### PR TITLE
cluster: enable podresource FG

### DIFF
--- a/cluster/kind-replica1.sh
+++ b/cluster/kind-replica1.sh
@@ -26,6 +26,8 @@ kubeadmConfigPatches:
   cpuManagerReconcilePeriod: "5s"
   topologyManagerPolicy: "single-numa-node"
   reservedSystemCPUs: "1"
+  featureGates:
+    KubeletPodResourcesGetAllocatable: true
 nodes:
 - role: control-plane
 - role: worker


### PR DESCRIPTION
The new GetAllocatableResources API is alpha, so it
needs to be explicitly enabled using a FG.

Signed-off-by: Francesco Romani <fromani@redhat.com>