### PR TITLE
kind: add workaround for 1.21

### DIFF
--- a/cluster/kind-replica1.sh
+++ b/cluster/kind-replica1.sh
@@ -30,6 +30,7 @@ kubeadmConfigPatches:
   reservedSystemCPUs: "1"
   featureGates:
     KubeletPodResourcesGetAllocatable: true
+  cgroupDriver: "cgroupfs"
 nodes:
 EOF
 


### PR DESCRIPTION
In the future we should just require/download a recent enough kind
binary.

Signed-off-by: Francesco Romani <fromani@redhat.com>