### PR TITLE
Update TAS environment setup to work with latest sample-device-plugin

### DIFF
--- a/environment/topology-aware-scheduling-quick.sh
+++ b/environment/topology-aware-scheduling-quick.sh
@@ -3,6 +3,7 @@
 ACTION=${1}
 
 DEVICE_PLUGIN_MANIFESTS="https://raw.githubusercontent.com/k8stopologyawareschedwg/sample-device-plugin/master/manifests"
+DEVICE_PLUGIN_CONFIGS="https://raw.githubusercontent.com/k8stopologyawareschedwg/sample-device-plugin/master/config"
 TOPOLOGYAPI_MANIFESTS="https://raw.githubusercontent.com/k8stopologyawareschedwg/noderesourcetopology-api/master/manifests"
 
 if [ -z "${KUBECONFIG}" ]; then
@@ -15,6 +16,8 @@ k8sdo() {
 }
 
 start() {
+	k8sdo create -f ${DEVICE_PLUGIN_CONFIGS}/device-A-configmap.yaml
+	k8sdo create -f ${DEVICE_PLUGIN_CONFIGS}/device-B-configmap.yaml
 	k8sdo create -f ${DEVICE_PLUGIN_MANIFESTS}/devicepluginA-ds.yaml
 	k8sdo create -f ${DEVICE_PLUGIN_MANIFESTS}/devicepluginB-ds.yaml
 	k8sdo create -f ${TOPOLOGYAPI_MANIFESTS}/crd.yaml
@@ -25,6 +28,8 @@ stop() {
 	k8sdo delete -f ${TOPOLOGYAPI_MANIFESTS}/crd.yaml
 	k8sdo delete -f ${DEVICE_PLUGIN_MANIFESTS}/devicepluginB-ds.yaml
 	k8sdo delete -f ${DEVICE_PLUGIN_MANIFESTS}/devicepluginA-ds.yaml
+	k8sdo delete -f ${DEVICE_PLUGIN_CONFIGS}/device-A-configmap.yaml
+	k8sdo delete -f ${DEVICE_PLUGIN_CONFIGS}/device-B-configmap.yaml
 }
 
 help() {


### PR DESCRIPTION
With the introduction of configmaps in the sample-device-plugin in PR:
https://github.com/k8stopologyawareschedwg/sample-device-plugin/pull/3
we need to make sure the TAS environment setup is updated and continues
to work as expected.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>